### PR TITLE
Use XDG_CONFIG_HOME for config folder

### DIFF
--- a/sentinelhub/config.py
+++ b/sentinelhub/config.py
@@ -216,5 +216,5 @@ class SHConfig(_SHConfig):
     @classmethod
     def get_config_location(cls) -> str:
         """Returns the default location of the user configuration file on disk."""
-        user_folder = os.path.expanduser("~")
-        return os.path.join(user_folder, ".config", "sentinelhub", "config.toml")
+        config_folder = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        return os.path.join(config_folder, "sentinelhub", "config.toml")


### PR DESCRIPTION
Retrieve the default folder for storing config files from the XDG_CONFIG_HOME env var if present. Fall back to "~/.config" if the env var is not declared.

This allows customization of the config folder. For example when running on a YARN cluster, ~ expands to /home/ and attempting to save the config raises a permission error.